### PR TITLE
Add single life text

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -111,7 +111,11 @@ class Game extends Component {
 		let sm = '';
 		let bm ='';
 		let sc = '';
-		if (lives > 0) {
+		if (lives === 0) {
+            sm = `Out of time, you have 1 life remaining!`;
+            bm = 'Try again.';
+            sc = 'same-level';
+		} else if (lives > 0) {
 			sm = `Out of time, you have ${lives} lives remaining!`;
 			bm = 'Try again.';
 			sc = 'same-level';

--- a/src/Game.js
+++ b/src/Game.js
@@ -112,9 +112,9 @@ class Game extends Component {
 		let bm ='';
 		let sc = '';
 		if (lives === 0) {
-            sm = `Out of time, you have 1 life remaining!`;
-            bm = 'Try again.';
-            sc = 'same-level';
+            		sm = `Out of time, you have 1 life remaining!`;
+            		bm = 'Try again.';
+            		sc = 'same-level';
 		} else if (lives > 0) {
 			sm = `Out of time, you have ${lives} lives remaining!`;
 			bm = 'Try again.';


### PR DESCRIPTION
Fixes scenario where player has only one life remaining, but the text is still plural for "lives" instead of "life."